### PR TITLE
Add toggle time bullet command with hotkey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Auto-timestamp task lists**: Converts `-[t]` to `- [HH:MM]` with current time when you press Space
 - **Timestamp continuity**: When pressing Enter on a timestamped list item, the new line automatically includes the
   current time
+- **Toggle timestamps**: Add or remove timestamps from any line with a customizable hotkey
 - **Minimal interference**: Works naturally within your existing workflow
 - **No configuration needed**: Simple, intuitive functionality right out of the box
 
@@ -24,6 +25,15 @@
 1. Press Enter at the end of a line that starts with `- [{{time_stamp}}]`
 2. A new list item with the current time is automatically created
 3. Continue with your notes
+
+### Toggle time bullets
+
+1. Place your cursor on any line
+2. Use the hotkey you've assigned to "Toggle time bullet" (set in Settings → Hotkeys)
+3. The command will:
+   - Add a timestamp to regular bullets: `- ` becomes `- [HH:MM] `
+   - Remove timestamps from time bullets: `- [HH:MM] ` becomes `- `
+   - Add both bullet and timestamp to plain text lines
 
 ## Use Cases
 

--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,11 @@ export default class TimeBulletPlugin extends Plugin {
 	public settings: TimeBulletPluginSettings;
 	private readonly timeBulletPattern = '-[t]';
 	private readonly invalidFormatFallbackText = 'invalid_format';
+	
+	// Regex patterns for toggle functionality
+	private readonly TIME_BULLET_REGEX = /^- \[([^\]]+)\](.*)$/;
+	private readonly INDENT_REGEX = /^(\s*)/;
+	private readonly BULLET_REGEX = /^[-*+](.*)$/;
 
 	private get timeStampFormat() {
 		// Use `||` to handle the case of an empty string.
@@ -37,6 +42,15 @@ export default class TimeBulletPlugin extends Plugin {
 
 		await this.loadSettings();
 		this.addSettingTab(new TimeBulletSettingTab(this.app, this));
+
+		// Add command for hotkey support
+		this.addCommand({
+			id: 'toggle-time-bullet',
+			name: 'Toggle time bullet',
+			editorCallback: (editor: Editor) => {
+				this.toggleTimeBullet(editor);
+			}
+		});
 
 		// Register the Enter and Space key handler
 		this.registerDomEvent(document, 'keydown', (event: KeyboardEvent) => {
@@ -133,6 +147,109 @@ export default class TimeBulletPlugin extends Plugin {
 		} catch (_) {
 			// If for some reason the format used results in an error, we will expose that error to the user by showing `invalid_format`.
 			return this.invalidFormatFallbackText;
+		}
+	}
+	
+	private getIndentation(line: string): string {
+		const match = line.match(this.INDENT_REGEX);
+		return match ? match[1] : '';
+	}
+	
+	private calculateCursorOffset(oldLength: number, newLength: number, currentPosition: number): number {
+		const lengthDiff = newLength - oldLength;
+		return Math.max(0, currentPosition + lengthDiff);
+	}
+
+	private toggleTimeBullet(editor: Editor) {
+		const cursor = editor.getCursor();
+		const currentLine = cursor.line;
+		const originalCursorCh = cursor.ch;
+		const currentLineContent = editor.getLine(currentLine);
+		const trimmedContent = currentLineContent.trim();
+		
+		// Check if line already has a time bullet
+		const timeBulletMatch = trimmedContent.match(this.TIME_BULLET_REGEX);
+		
+		if (timeBulletMatch) {
+			// Has time bullet - check if it's a valid timestamp
+			const [fullMatch, capturedTimeStamp, restOfLine] = timeBulletMatch;
+			const isValidTimestamp = dayjs(capturedTimeStamp, this.timeStampFormat, true).isValid();
+			
+			if (isValidTimestamp) {
+				// Remove time bullet, keep as normal bullet
+				const indent = this.getIndentation(currentLineContent);
+				// Trim all leading spaces from restOfLine
+				const trimmedRestOfLine = restOfLine.trimStart();
+				const newContent = `${indent}- ${trimmedRestOfLine}`;
+				
+				editor.setLine(currentLine, newContent);
+				
+				// Preserve cursor position, adjusting for the removed timestamp
+				const newCursorCh = this.calculateCursorOffset(
+					currentLineContent.length,
+					newContent.length,
+					originalCursorCh
+				);
+				editor.setCursor({
+					line: currentLine,
+					ch: newCursorCh
+				});
+				return;
+			}
+		}
+		
+		// No time bullet or invalid timestamp - add time bullet
+		const timestamp = this.generateTimestamp();
+		const indent = this.getIndentation(currentLineContent);
+		
+		// Check if line starts with a normal bullet (after indentation)
+		const normalBulletMatch = trimmedContent.match(this.BULLET_REGEX);
+		
+		if (normalBulletMatch) {
+			// Replace normal bullet with time bullet
+			const [, restOfLine] = normalBulletMatch;
+			// Trim leading spaces from restOfLine and add exactly one space
+			const trimmedRestOfLine = restOfLine.trimStart();
+			const newContent = `${indent}- [${timestamp}] ${trimmedRestOfLine}`;
+			
+			editor.setLine(currentLine, newContent);
+			
+			// Preserve cursor position, adjusting for the added timestamp
+			const newCursorCh = this.calculateCursorOffset(
+				currentLineContent.length,
+				newContent.length,
+				originalCursorCh
+			);
+			editor.setCursor({
+				line: currentLine,
+				ch: newCursorCh
+			});
+		} else if (trimmedContent === '') {
+			// Empty line - add time bullet
+			const newContent = `${indent}- [${timestamp}] `;
+			editor.setLine(currentLine, newContent);
+			
+			// Keep cursor at end of new content
+			editor.setCursor({
+				line: currentLine,
+				ch: newContent.length
+			});
+		} else {
+			// Line has content but no bullet - add time bullet at beginning
+			const newContent = `${indent}- [${timestamp}] ${trimmedContent}`;
+			
+			editor.setLine(currentLine, newContent);
+			
+			// Preserve cursor position, adjusting for the added timestamp and bullet
+			const newCursorCh = this.calculateCursorOffset(
+				currentLineContent.length,
+				newContent.length,
+				originalCursorCh
+			);
+			editor.setCursor({
+				line: currentLine,
+				ch: newCursorCh
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Added a new "Toggle time bullet" command that can be assigned to a hotkey
- Allows users to quickly add or remove timestamps from any line
- Preserves cursor position for seamless editing experience

## What's Changed
- Added `toggleTimeBullet()` method in `main.ts` that:
  - Converts regular bullets `- ` to timestamped bullets `- [HH:MM] `
  - Removes timestamps from existing time bullets
  - Adds both bullet and timestamp to plain text lines
  - Maintains cursor position during all operations
  
- Refactored code for better maintainability:
  - Extracted regex patterns as class constants
  - Added helper methods `getIndentation()` and `calculateCursorOffset()`
  - Fixed space accumulation bug with consistent `trimStart()` usage

- Updated README.md to document the new toggle functionality

## Testing
- Tested toggle on regular bullets
- Tested toggle on time bullets with valid timestamps
- Tested toggle on plain text lines
- Tested cursor position preservation
- Verified no space accumulation after multiple toggles

## Breaking Changes
None - this is a new feature that doesn't affect existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)