### PR TITLE
Add toggle time bullet command with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- **Auto-timestamp task lists**: Converts `-[t]` to `- [HH:MM]` with current time when you press Space
+- **Auto-timestamp task lists**: Converts `-[t]` to `- [HH:mm]` with current time when you press Space
 - **Timestamp continuity**: When pressing Enter on a timestamped list item, the new line automatically includes the
   current time
 - **Toggle timestamps**: Add or remove timestamps from any line with a customizable hotkey
@@ -17,7 +17,7 @@
 
 1. Type `-[t]`
 2. Press the Space key
-3. The text becomes `- [{{time_stamp}}]` with the current time formatted based on your settings (default is HH:MM).
+3. The text becomes `- [{{time_stamp}}]` with the current time formatted based on your settings (default is HH:mm).
 4. Continue writing your note
 
 ### Continuing a timestamped list
@@ -31,8 +31,8 @@
 1. Place your cursor on any line
 2. Use the hotkey you've assigned to "Toggle time bullet" (set in Settings → Hotkeys)
 3. The command will:
-   - Add a timestamp to regular bullets: `- ` becomes `- [HH:MM] `
-   - Remove timestamps from time bullets: `- [HH:MM] ` becomes `- `
+   - Add a timestamp to regular bullets: `- ` becomes `- [HH:mm] `
+   - Remove timestamps from time bullets: `- [HH:mm] ` becomes `- `
    - Add both bullet and timestamp to plain text lines
 
 ## Use Cases
@@ -44,7 +44,7 @@
 
 ## Settings
 
-- **Time format**: (default is HH:MM) - Customize your time format using Dayjs formatting found on the [dayjs documentation](https://day.js.org/docs/en/display/format)
+- **Time format**: (default is HH:mm) - Customize your time format using Dayjs formatting found on the [dayjs documentation](https://day.js.org/docs/en/display/format)
 - **Use UTC**: (default is true) - Use UTC time when creating a timestamp. If false, time will be local to your machine.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Auto-timestamp task lists**: Converts `-[t]` to `- [HH:MM]` with current time when you press Space
 - **Timestamp continuity**: When pressing Enter on a timestamped list item, the new line automatically includes the
   current time
+- **Toggle timestamps**: Add or remove timestamps from any line with a customizable hotkey
 - **Minimal interference**: Works naturally within your existing workflow
 - **No configuration needed**: Simple, intuitive functionality right out of the box
 
@@ -24,6 +25,15 @@
 1. Press Enter at the end of a line that starts with `- [{{time_stamp}}]`
 2. A new list item with the current time is automatically created
 3. Continue with your notes
+
+### Toggle time bullets
+
+1. Place your cursor on any line
+2. Use the hotkey you've assigned to "Toggle time bullet" (set in Settings → Hotkeys)
+3. The command will:
+   - Add a timestamp to regular bullets: `- ` becomes `- [HH:MM] `
+   - Remove timestamps from time bullets: `- [HH:MM] ` becomes `- `
+   - Add both bullet and timestamp to plain text lines
 
 ## Use Cases
 

--- a/main.test.ts
+++ b/main.test.ts
@@ -12,6 +12,7 @@ type PluginInternals = {
 	generateTimestamp: () => string;
 	handleSpaceInEditor: (editor: FakeEditor, event: KeyboardEvent) => void;
 	handleEnterInEditor: (editor: FakeEditor, event: KeyboardEvent) => void;
+	toggleTimeBullet: (editor: FakeEditor) => void;
 };
 
 type FakeLeaf = {
@@ -151,6 +152,88 @@ describe('TimeBulletPlugin', () => {
 		expect(editor.cursor).toEqual({
 			line: 1,
 			ch: 2 + '- [09:30]'.length - '-'.length,
+		});
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it('adds a time bullet to a regular bullet and keeps the cursor with the content', () => {
+		const { plugin } = createPlugin();
+		const internals = plugin as unknown as PluginInternals;
+		plugin.settings = { ...DEFAULT_SETTINGS };
+
+		vi.spyOn(internals, 'generateTimestamp').mockReturnValue('09:30');
+
+		const editor = new FakeEditor(['- task'], { line: 0, ch: 2 });
+
+		internals.toggleTimeBullet(editor);
+
+		expect(editor.lines[0]).toBe('- [09:30] task');
+		expect(editor.cursor).toEqual({
+			line: 0,
+			ch: '- [09:30] '.length,
+		});
+	});
+
+	it('keeps the cursor in leading indentation when toggling a plain text line', () => {
+		const { plugin } = createPlugin();
+		const internals = plugin as unknown as PluginInternals;
+		plugin.settings = { ...DEFAULT_SETTINGS };
+
+		vi.spyOn(internals, 'generateTimestamp').mockReturnValue('09:30');
+
+		const editor = new FakeEditor(['  task'], { line: 0, ch: 1 });
+
+		internals.toggleTimeBullet(editor);
+
+		expect(editor.lines[0]).toBe('  - [09:30] task');
+		expect(editor.cursor).toEqual({
+			line: 0,
+			ch: 1,
+		});
+	});
+
+	it('preserves non-dash bullet markers when toggling on and off', () => {
+		const { plugin } = createPlugin();
+		const internals = plugin as unknown as PluginInternals;
+		plugin.settings = { ...DEFAULT_SETTINGS };
+
+		vi.spyOn(internals, 'generateTimestamp').mockReturnValue('09:30');
+
+		const editor = new FakeEditor(['* task'], { line: 0, ch: 2 });
+
+		internals.toggleTimeBullet(editor);
+
+		expect(editor.lines[0]).toBe('* [09:30] task');
+		expect(editor.cursor).toEqual({
+			line: 0,
+			ch: '* [09:30] '.length,
+		});
+
+		internals.toggleTimeBullet(editor);
+
+		expect(editor.lines[0]).toBe('* task');
+		expect(editor.cursor).toEqual({
+			line: 0,
+			ch: 2,
+		});
+	});
+
+	it('continues timestamped lists with the current bullet marker', () => {
+		const { plugin } = createPlugin();
+		const internals = plugin as unknown as PluginInternals;
+		plugin.settings = { ...DEFAULT_SETTINGS };
+
+		vi.spyOn(internals, 'generateTimestamp').mockReturnValue('09:30');
+
+		const editor = new FakeEditor(['* [08:00] start', '* next'], { line: 1, ch: 2 });
+		const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true });
+
+		internals.handleEnterInEditor(editor, event);
+
+		expect(editor.lines[1]).toBe('* [09:30] next');
+		expect(editor.cursor).toEqual({
+			line: 1,
+			ch: '* [09:30] '.length,
 		});
 		expect(event.defaultPrevented).toBe(true);
 	});

--- a/main.ts
+++ b/main.ts
@@ -23,6 +23,10 @@ export default class TimeBulletPlugin extends Plugin {
 	private readonly timeBulletPattern = '-[t]';
 	private readonly invalidFormatFallbackText = 'invalid_format';
 	private readonly registeredDocuments = new WeakSet<Document>();
+	// Regex patterns for toggle functionality
+	private readonly TIME_BULLET_REGEX = /^- \[([^\]]+)\](.*)$/;
+	private readonly INDENT_REGEX = /^(\s*)/;
+	private readonly BULLET_REGEX = /^[-*+](.*)$/;
 
 	private get timeStampFormat() {
 		// Use `||` to handle the case of an empty string.
@@ -38,6 +42,15 @@ export default class TimeBulletPlugin extends Plugin {
 
 		await this.loadSettings();
 		this.addSettingTab(new TimeBulletSettingTab(this.app, this));
+
+		// Add command for hotkey support
+		this.addCommand({
+			id: 'toggle-time-bullet',
+			name: 'Toggle time bullet',
+			editorCallback: (editor: Editor) => {
+				this.toggleTimeBullet(editor);
+			},
+		});
 
 		this.registerWorkspaceKeyHandlers();
 	}
@@ -177,6 +190,109 @@ export default class TimeBulletPlugin extends Plugin {
 		} catch (_) {
 			// If for some reason the format used results in an error, we will expose that error to the user by showing `invalid_format`.
 			return this.invalidFormatFallbackText;
+		}
+	}
+	
+	private getIndentation(line: string): string {
+		const match = line.match(this.INDENT_REGEX);
+		return match ? match[1] : '';
+	}
+	
+	private calculateCursorOffset(oldLength: number, newLength: number, currentPosition: number): number {
+		const lengthDiff = newLength - oldLength;
+		return Math.max(0, currentPosition + lengthDiff);
+	}
+
+	private toggleTimeBullet(editor: Editor) {
+		const cursor = editor.getCursor();
+		const currentLine = cursor.line;
+		const originalCursorCh = cursor.ch;
+		const currentLineContent = editor.getLine(currentLine);
+		const trimmedContent = currentLineContent.trim();
+		
+		// Check if line already has a time bullet
+		const timeBulletMatch = trimmedContent.match(this.TIME_BULLET_REGEX);
+		
+		if (timeBulletMatch) {
+			// Has time bullet - check if it's a valid timestamp
+			const [fullMatch, capturedTimeStamp, restOfLine] = timeBulletMatch;
+			const isValidTimestamp = dayjs(capturedTimeStamp, this.timeStampFormat, true).isValid();
+			
+			if (isValidTimestamp) {
+				// Remove time bullet, keep as normal bullet
+				const indent = this.getIndentation(currentLineContent);
+				// Trim all leading spaces from restOfLine
+				const trimmedRestOfLine = restOfLine.trimStart();
+				const newContent = `${indent}- ${trimmedRestOfLine}`;
+				
+				editor.setLine(currentLine, newContent);
+				
+				// Preserve cursor position, adjusting for the removed timestamp
+				const newCursorCh = this.calculateCursorOffset(
+					currentLineContent.length,
+					newContent.length,
+					originalCursorCh
+				);
+				editor.setCursor({
+					line: currentLine,
+					ch: newCursorCh
+				});
+				return;
+			}
+		}
+		
+		// No time bullet or invalid timestamp - add time bullet
+		const timestamp = this.generateTimestamp();
+		const indent = this.getIndentation(currentLineContent);
+		
+		// Check if line starts with a normal bullet (after indentation)
+		const normalBulletMatch = trimmedContent.match(this.BULLET_REGEX);
+		
+		if (normalBulletMatch) {
+			// Replace normal bullet with time bullet
+			const [, restOfLine] = normalBulletMatch;
+			// Trim leading spaces from restOfLine and add exactly one space
+			const trimmedRestOfLine = restOfLine.trimStart();
+			const newContent = `${indent}- [${timestamp}] ${trimmedRestOfLine}`;
+			
+			editor.setLine(currentLine, newContent);
+			
+			// Preserve cursor position, adjusting for the added timestamp
+			const newCursorCh = this.calculateCursorOffset(
+				currentLineContent.length,
+				newContent.length,
+				originalCursorCh
+			);
+			editor.setCursor({
+				line: currentLine,
+				ch: newCursorCh
+			});
+		} else if (trimmedContent === '') {
+			// Empty line - add time bullet
+			const newContent = `${indent}- [${timestamp}] `;
+			editor.setLine(currentLine, newContent);
+			
+			// Keep cursor at end of new content
+			editor.setCursor({
+				line: currentLine,
+				ch: newContent.length
+			});
+		} else {
+			// Line has content but no bullet - add time bullet at beginning
+			const newContent = `${indent}- [${timestamp}] ${trimmedContent}`;
+			
+			editor.setLine(currentLine, newContent);
+			
+			// Preserve cursor position, adjusting for the added timestamp and bullet
+			const newCursorCh = this.calculateCursorOffset(
+				currentLineContent.length,
+				newContent.length,
+				originalCursorCh
+			);
+			editor.setCursor({
+				line: currentLine,
+				ch: newCursorCh
+			});
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,17 @@ interface TimeBulletPluginSettings {
 	isUTC: boolean;
 }
 
+type BulletMarker = '-' | '*' | '+';
+
+type BulletMatch = {
+	marker: BulletMarker;
+	restOfLine: string;
+};
+
+type TimeBulletMatch = BulletMatch & {
+	timestamp: string;
+};
+
 export const DEFAULT_SETTINGS: TimeBulletPluginSettings = {
 	timeStampFormat: 'HH:mm',
 	isUTC: true,
@@ -22,11 +33,10 @@ export default class TimeBulletPlugin extends Plugin {
 	public settings: TimeBulletPluginSettings;
 	private readonly timeBulletPattern = '-[t]';
 	private readonly invalidFormatFallbackText = 'invalid_format';
+	private readonly timeBulletLinePattern = /^([-*+]) \[([^\]]+)\](.*)$/;
+	private readonly indentationPattern = /^(\s*)/;
+	private readonly bulletLinePattern = /^([-*+])(.*)$/;
 	private readonly registeredDocuments = new WeakSet<Document>();
-	// Regex patterns for toggle functionality
-	private readonly TIME_BULLET_REGEX = /^- \[([^\]]+)\](.*)$/;
-	private readonly INDENT_REGEX = /^(\s*)/;
-	private readonly BULLET_REGEX = /^[-*+](.*)$/;
 
 	private get timeStampFormat() {
 		// Use `||` to handle the case of an empty string.
@@ -146,21 +156,34 @@ export default class TimeBulletPlugin extends Plugin {
 
 			if (this.doesLineStartWithTimeBullet(previousLine)) {
 				const currentLineContent = editor.getLine(currentLine);
+				const indentation = this.getIndentation(currentLineContent);
+				const currentBullet = this.getBulletMatch(currentLineContent);
 
-				/**
-				 * We don't want to strip the whitespace or otherwise change anything about the content in this new line.
-				 * To achieve this, we will replace the bullet with a timestamped bullet. This preserves whitespace.
-				 */
-				const bulletToReplace = '-';
-				const timeStampedBullet = `- [${this.generateTimestamp()}]`;
-				const updatedLineContent = currentLineContent.replace(bulletToReplace, timeStampedBullet);
+				if (!currentBullet) {
+					return;
+				}
+
+				const currentLineWithoutIndentation = currentLineContent.slice(indentation.length);
+				const currentTimestamp = this.generateTimestamp();
+				const trimmedRestOfLine = currentBullet.restOfLine.trimStart();
+				const oldPrefixLength = currentLineWithoutIndentation.length - trimmedRestOfLine.length;
+				const newPrefixLength = `${currentBullet.marker} [${currentTimestamp}] `.length;
+				const updatedLineContent = this.buildTimeBulletLine(
+					indentation,
+					currentBullet.marker,
+					currentTimestamp,
+					currentBullet.restOfLine,
+				);
 
 				editor.setLine(currentLine, updatedLineContent);
 
-				// Remove the thing we replaced, add the thing we added.
-				const updatedCursorCh = currentCursorCh + timeStampedBullet.length - bulletToReplace.length;
-
-				// Position cursor after the timestamp
+				const updatedCursorCh = this.calculateUpdatedCursorPosition(
+					currentCursorCh,
+					indentation.length,
+					oldPrefixLength,
+					newPrefixLength,
+					updatedLineContent.length,
+				);
 				editor.setCursor({
 					line: currentLine,
 					ch: updatedCursorCh,
@@ -173,11 +196,7 @@ export default class TimeBulletPlugin extends Plugin {
 	}
 
 	private doesLineStartWithTimeBullet(line: string) {
-		const timeStampMatches = line.trim().match(/^- \[([^\]]+)\]/); // Capture contents within the first `[..]`
-		if (!timeStampMatches || !Array.isArray(timeStampMatches) || timeStampMatches.length < 2) return false;
-
-		const [, capturedTimeStamp] = timeStampMatches;
-		return dayjs(capturedTimeStamp, this.timeStampFormat, true).isValid();
+		return this.getValidTimeBulletMatch(line) !== null;
 	}
 
 	private generateTimestamp(): string {
@@ -192,15 +211,71 @@ export default class TimeBulletPlugin extends Plugin {
 			return this.invalidFormatFallbackText;
 		}
 	}
-	
+
 	private getIndentation(line: string): string {
-		const match = line.match(this.INDENT_REGEX);
+		const match = line.match(this.indentationPattern);
 		return match ? match[1] : '';
 	}
-	
-	private calculateCursorOffset(oldLength: number, newLength: number, currentPosition: number): number {
-		const lengthDiff = newLength - oldLength;
-		return Math.max(0, currentPosition + lengthDiff);
+
+	private getBulletMatch(line: string): BulletMatch | null {
+		const match = line.trimStart().match(this.bulletLinePattern);
+		if (!match) {
+			return null;
+		}
+
+		const [, marker, restOfLine] = match;
+		return {
+			marker: marker as BulletMarker,
+			restOfLine,
+		};
+	}
+
+	private getValidTimeBulletMatch(line: string): TimeBulletMatch | null {
+		const match = line.trimStart().match(this.timeBulletLinePattern);
+		if (!match) {
+			return null;
+		}
+
+		const [, marker, timestamp, restOfLine] = match;
+		if (!dayjs(timestamp, this.timeStampFormat, true).isValid()) {
+			return null;
+		}
+
+		return {
+			marker: marker as BulletMarker,
+			timestamp,
+			restOfLine,
+		};
+	}
+
+	private buildBulletLine(indent: string, marker: BulletMarker, text: string): string {
+		const trimmedText = text.trimStart();
+		return trimmedText ? `${indent}${marker} ${trimmedText}` : `${indent}${marker} `;
+	}
+
+	private buildTimeBulletLine(indent: string, marker: BulletMarker, timestamp: string, text: string): string {
+		const trimmedText = text.trimStart();
+		return trimmedText ? `${indent}${marker} [${timestamp}] ${trimmedText}` : `${indent}${marker} [${timestamp}] `;
+	}
+
+	private calculateUpdatedCursorPosition(
+		currentPosition: number,
+		prefixStart: number,
+		oldPrefixLength: number,
+		newPrefixLength: number,
+		newLineLength: number,
+	): number {
+		if (currentPosition < prefixStart) {
+			return currentPosition;
+		}
+
+		const oldPrefixEnd = prefixStart + oldPrefixLength;
+		if (currentPosition <= oldPrefixEnd) {
+			return Math.min(prefixStart + newPrefixLength, newLineLength);
+		}
+
+		const updatedPosition = currentPosition + newPrefixLength - oldPrefixLength;
+		return Math.max(0, Math.min(updatedPosition, newLineLength));
 	}
 
 	private toggleTimeBullet(editor: Editor) {
@@ -208,92 +283,74 @@ export default class TimeBulletPlugin extends Plugin {
 		const currentLine = cursor.line;
 		const originalCursorCh = cursor.ch;
 		const currentLineContent = editor.getLine(currentLine);
-		const trimmedContent = currentLineContent.trim();
-		
-		// Check if line already has a time bullet
-		const timeBulletMatch = trimmedContent.match(this.TIME_BULLET_REGEX);
-		
+		const indentation = this.getIndentation(currentLineContent);
+		const currentLineWithoutIndentation = currentLineContent.slice(indentation.length);
+		const timeBulletMatch = this.getValidTimeBulletMatch(currentLineContent);
+
 		if (timeBulletMatch) {
-			// Has time bullet - check if it's a valid timestamp
-			const [fullMatch, capturedTimeStamp, restOfLine] = timeBulletMatch;
-			const isValidTimestamp = dayjs(capturedTimeStamp, this.timeStampFormat, true).isValid();
-			
-			if (isValidTimestamp) {
-				// Remove time bullet, keep as normal bullet
-				const indent = this.getIndentation(currentLineContent);
-				// Trim all leading spaces from restOfLine
-				const trimmedRestOfLine = restOfLine.trimStart();
-				const newContent = `${indent}- ${trimmedRestOfLine}`;
-				
-				editor.setLine(currentLine, newContent);
-				
-				// Preserve cursor position, adjusting for the removed timestamp
-				const newCursorCh = this.calculateCursorOffset(
-					currentLineContent.length,
-					newContent.length,
-					originalCursorCh
-				);
-				editor.setCursor({
-					line: currentLine,
-					ch: newCursorCh
-				});
-				return;
-			}
+			const trimmedRestOfLine = timeBulletMatch.restOfLine.trimStart();
+			const oldPrefixLength = currentLineWithoutIndentation.length - trimmedRestOfLine.length;
+			const newPrefixLength = `${timeBulletMatch.marker} `.length;
+			const updatedLineContent = this.buildBulletLine(
+				indentation,
+				timeBulletMatch.marker,
+				timeBulletMatch.restOfLine,
+			);
+
+			editor.setLine(currentLine, updatedLineContent);
+			editor.setCursor({
+				line: currentLine,
+				ch: this.calculateUpdatedCursorPosition(
+					originalCursorCh,
+					indentation.length,
+					oldPrefixLength,
+					newPrefixLength,
+					updatedLineContent.length,
+				),
+			});
+			return;
 		}
-		
-		// No time bullet or invalid timestamp - add time bullet
+
 		const timestamp = this.generateTimestamp();
-		const indent = this.getIndentation(currentLineContent);
-		
-		// Check if line starts with a normal bullet (after indentation)
-		const normalBulletMatch = trimmedContent.match(this.BULLET_REGEX);
-		
-		if (normalBulletMatch) {
-			// Replace normal bullet with time bullet
-			const [, restOfLine] = normalBulletMatch;
-			// Trim leading spaces from restOfLine and add exactly one space
-			const trimmedRestOfLine = restOfLine.trimStart();
-			const newContent = `${indent}- [${timestamp}] ${trimmedRestOfLine}`;
-			
-			editor.setLine(currentLine, newContent);
-			
-			// Preserve cursor position, adjusting for the added timestamp
-			const newCursorCh = this.calculateCursorOffset(
-				currentLineContent.length,
-				newContent.length,
-				originalCursorCh
+		const bulletMatch = this.getBulletMatch(currentLineContent);
+		if (bulletMatch) {
+			const trimmedRestOfLine = bulletMatch.restOfLine.trimStart();
+			const oldPrefixLength = currentLineWithoutIndentation.length - trimmedRestOfLine.length;
+			const newPrefixLength = `${bulletMatch.marker} [${timestamp}] `.length;
+			const updatedLineContent = this.buildTimeBulletLine(
+				indentation,
+				bulletMatch.marker,
+				timestamp,
+				bulletMatch.restOfLine,
 			);
+
+			editor.setLine(currentLine, updatedLineContent);
 			editor.setCursor({
 				line: currentLine,
-				ch: newCursorCh
+				ch: this.calculateUpdatedCursorPosition(
+					originalCursorCh,
+					indentation.length,
+					oldPrefixLength,
+					newPrefixLength,
+					updatedLineContent.length,
+				),
 			});
-		} else if (trimmedContent === '') {
-			// Empty line - add time bullet
-			const newContent = `${indent}- [${timestamp}] `;
-			editor.setLine(currentLine, newContent);
-			
-			// Keep cursor at end of new content
-			editor.setCursor({
-				line: currentLine,
-				ch: newContent.length
-			});
-		} else {
-			// Line has content but no bullet - add time bullet at beginning
-			const newContent = `${indent}- [${timestamp}] ${trimmedContent}`;
-			
-			editor.setLine(currentLine, newContent);
-			
-			// Preserve cursor position, adjusting for the added timestamp and bullet
-			const newCursorCh = this.calculateCursorOffset(
-				currentLineContent.length,
-				newContent.length,
-				originalCursorCh
-			);
-			editor.setCursor({
-				line: currentLine,
-				ch: newCursorCh
-			});
+			return;
 		}
+
+		const updatedLineContent = this.buildTimeBulletLine(indentation, '-', timestamp, currentLineWithoutIndentation);
+		const newPrefixLength = `- [${timestamp}] `.length;
+		editor.setLine(currentLine, updatedLineContent);
+		editor.setCursor({
+			line: currentLine,
+			ch: this.calculateUpdatedCursorPosition(
+				originalCursorCh,
+				indentation.length,
+				0,
+				newPrefixLength,
+				updatedLineContent.length,
+			),
+		});
 	}
 
 	async loadSettings() {

--- a/test-support/obsidian.ts
+++ b/test-support/obsidian.ts
@@ -9,6 +9,8 @@ export class Plugin {
 
 	addSettingTab() {}
 
+	addCommand() {}
+
 	register(cb: () => void) {
 		return cb;
 	}


### PR DESCRIPTION
## Summary
- add a toggle time bullet command that can be assigned to a hotkey
- preserve cursor placement correctly when timestamps are added or removed
- preserve bullet markers when toggling existing list items and keep the moved-window fix intact
- add regression tests for toggle behavior and correct the README time-format examples

## Testing
- npm test
- npm run build

This supersedes #5. The feature was initially proposed there and then ported onto this branch so it can be finished and merged from this repository.